### PR TITLE
Add support for deploying teleport on CoreOS

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,47 +1,16 @@
 # === Class teleport::config
 #
 # This class is called from teleport::init to install the config file
+# and the service definition.
 #
-# == Parameters
-#
-# [*config_path*]
-#   Path to teleport config file
-#
-# [*systemd_file*]
-#   Path to the teleport systemd file
-#
-class teleport::config {
-  case $teleport::init_style {
-    'systemd': {
-      file { $teleport::systemd_file:
-        mode    => '0644',
-        owner   => 'root',
-        group   => 'root',
-        content => template('teleport/teleport.systemd.erb'),
-      }~>
-      exec { 'teleport-systemd-reload':
-        command     => 'systemctl daemon-reload',
-        path        => [ '/usr/bin', '/bin', '/usr/sbin' ],
-        refreshonly => true,
-      }
-    }
-    'init': {
-      file { '/etc/init.d/teleport':
-        mode    => '0555',
-        owner   => 'root',
-        group   => 'root',
-        content => template('teleport/teleport.init.erb')
-      }
-    }
-    default: { fail('OS not supported') }
-  }
-
+class teleport::config(
+  Enum[present, absent] $ensure = present,
+) {
   file { $teleport::config_path:
-    ensure  => present,
+    ensure  => $ensure,
     owner   => 'root',
     group   => 'root',
     mode    => '0555',
-    notify  => Service['teleport'],
     content => template('teleport/teleport.yaml.erb')
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,34 +7,33 @@
 # [*config_path*]
 #   Path to teleport config file
 #
+# [*systemd_file*]
+#   Path to the teleport systemd file
+#
 class teleport::config {
-
-  if $teleport::init_style {
-
-    case $teleport::init_style {
-      'systemd': {
-        file { '/lib/systemd/system/teleport.service':
-          mode    => '0644',
-          owner   => 'root',
-          group   => 'root',
-          content => template('teleport/teleport.systemd.erb'),
-        }~>
-        exec { 'teleport-systemd-reload':
-          command     => 'systemctl daemon-reload',
-          path        => [ '/usr/bin', '/bin', '/usr/sbin' ],
-          refreshonly => true,
-        }
+  case $teleport::init_style {
+    'systemd': {
+      file { $teleport::systemd_file:
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+        content => template('teleport/teleport.systemd.erb'),
+      }~>
+      exec { 'teleport-systemd-reload':
+        command     => 'systemctl daemon-reload',
+        path        => [ '/usr/bin', '/bin', '/usr/sbin' ],
+        refreshonly => true,
       }
-      'init': {
-        file { '/etc/init.d/teleport':
-          mode    => '0555',
-          owner   => 'root',
-          group   => 'root',
-          content => template('teleport/teleport.init.erb')
-        }
-      }
-      default: { fail('OS not supported') }
     }
+    'init': {
+      file { '/etc/init.d/teleport':
+        mode    => '0555',
+        owner   => 'root',
+        group   => 'root',
+        content => template('teleport/teleport.init.erb')
+      }
+    }
+    default: { fail('OS not supported') }
   }
 
   file { $teleport::config_path:
@@ -45,5 +44,4 @@ class teleport::config {
     notify  => Service['teleport'],
     content => template('teleport/teleport.yaml.erb')
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,8 +175,8 @@ class teleport (
   $init_style            = $teleport::params::init_style,
   $manage_service        = true,
   $systemd_file          = '/lib/systemd/system/teleport.service',
-  $service_ensure        = 'running',
-  $service_enable        = true
+  $service_enable        = true,
+  $ensure                = present
 ) inherits teleport::params {
 
   validate_array($auth_servers)
@@ -186,15 +186,20 @@ class teleport (
   validate_bool($proxy_enable)
   validate_bool($proxy_ssl)
   validate_bool($manage_service)
-  validate_re($service_ensure, '^(running|stopped)$')
   validate_bool($service_enable)
   validate_array($auth_service_tokens)
 
-  anchor { 'teleport_first': }
-  ->
-  class { 'teleport::install': } ->
-  class { 'teleport::config': } ->
-  class { 'teleport::service': } ->
+  anchor { 'teleport_first': } ->
+  class { 'teleport::install':
+    ensure => $ensure,
+  } ->
+  class { 'teleport::config':
+    ensure => $ensure,
+  } ->
+  class { 'teleport::service':
+    ensure => $ensure,
+    manage_service => $manage_service,
+    init_style => $teleport::params::init_style,
+  } ->
   anchor { 'teleport_final': }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,9 @@
 # [*version*]
 #  Version of teleport to download
 #
+# [*archive_url*]
+#  URL for the teleport release archive
+#
 # [*archive_path*]
 #  Where to download the teleport tarball
 #
@@ -20,7 +23,7 @@
 #  Where to sylink the teleport web assets
 #
 # [*nodename*]
-#  Teleport nodename. 
+#  Teleport nodename.
 #  Defaults to $::fqdn fact
 #
 # [*data_dir*]
@@ -126,6 +129,9 @@
 # [*manage_service*]
 #  Whether puppet should manage and configure the service
 #
+# [*systemd_file*]
+#  Where puppet should store the systemd service configuration
+#
 # [*service_ensure*]
 #  State of the teleport service
 #
@@ -134,6 +140,7 @@
 #
 class teleport (
   $version               = $teleport::params::version,
+  $archive_url           = $teleport::params::archive_url,
   $archive_path          = $teleport::params::archive_path,
   $extract_path          = $teleport::params::extract_path,
   $bin_dir               = $teleport::params::bin_dir,
@@ -167,6 +174,7 @@ class teleport (
   $proxy_ssl_cert        = undef,
   $init_style            = $teleport::params::init_style,
   $manage_service        = true,
+  $systemd_file          = '/lib/systemd/system/teleport.service',
   $service_ensure        = 'running',
   $service_enable        = true
 ) inherits teleport::params {
@@ -190,5 +198,3 @@ class teleport (
   anchor { 'teleport_final': }
 
 }
-
-

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,15 +1,35 @@
 # === Class: teleport::install
 #
 # Installs teleport
-class teleport::install {
+class teleport::install(
+  Enum[present, absent] $ensure = present,
+) {
 
   include ::archive
 
+  $rootgroup = $facts['os']['family'] ? {
+    'Solaris'          => 'wheel',
+    /(Darwin|FreeBSD)/ => 'wheel',
+    default            => 'root',
+  }
+
+  $directory_ensure = $ensure ? {
+    present => directory,
+    absent => absent,
+  }
+  $link_ensure = $ensure ? {
+    present => link,
+    absent => absent,
+  }
+
+  file { $teleport::bin_dir:
+    ensure => $directory_ensure,
+  } ->
   file { $teleport::extract_path:
-    ensure => directory,
+    ensure => $directory_ensure,
   } ->
   archive { $teleport::archive_path:
-    ensure       => present,
+    ensure       => $ensure,
     extract      => true,
     extract_path => $teleport::extract_path,
     source       => $teleport::archive_url,
@@ -17,18 +37,16 @@ class teleport::install {
   } ->
   file {
     "${teleport::bin_dir}/tctl":
-      ensure => link,
+      ensure => $link_ensure,
       target => "${teleport::extract_path}/teleport/tctl";
     "${teleport::bin_dir}/teleport":
-      ensure => link,
+      ensure => $link_ensure,
       target => "${teleport::extract_path}/teleport/teleport";
     "${teleport::bin_dir}/tsh":
-      ensure => link,
+      ensure => $link_ensure,
       target => "${teleport::extract_path}/teleport/tsh";
     $teleport::assets_dir:
-      ensure => link,
+      ensure => $link_ensure,
       target => "${teleport::extract_path}/teleport/app"
   }
-
-
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,7 +12,7 @@ class teleport::install {
     ensure       => present,
     extract      => true,
     extract_path => $teleport::extract_path,
-    source       => "https://github.com/gravitational/teleport/releases/download/${teleport::version}/teleport-${teleport::version}-linux-amd64-bin.tar.gz",
+    source       => $teleport::archive_url,
     creates      => "${teleport::extract_path}/teleport"
   } ->
   file {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@
 class teleport::params {
 
   $version         = 'v1.0.0'
+  $archive_url     = 'https://github.com/gravitational/teleport/releases/download/v1.0.0/teleport-v1.0.0-linux-amd64-bin.tar.gz'
   $archive_path    = '/tmp/teleport.tar.gz'
   $extract_path    = "/opt/teleport-${version}"
   $bin_dir         = '/usr/local/bin'
@@ -33,6 +34,9 @@ class teleport::params {
       } else {
         $init_style = 'systemd'
       }
+    }
+    'CoreOS': {
+      $init_style = 'systemd'
     }
     default: { fail('Unsupported OS') }
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,13 +3,44 @@
 # This class is meant to be called from teleport::init
 # It ensure the service is running
 #
-class teleport::service {
-
-  if $teleport::manage_service == true and $teleport::init_style {
+class teleport::service(
+  Boolean $manage_service = true,
+  Enum[present, absent] $ensure = present,
+  String $init_style = 'systemd',
+) {
+  if $manage_service == true {
+    case $init_style {
+      'systemd': {
+        file { $teleport::systemd_file:
+          ensure  => $ensure,
+          mode    => '0644',
+          owner   => 'root',
+          group   => 'root',
+          content => template('teleport/teleport.systemd.erb'),
+        }->
+        exec { 'teleport-systemd-reload':
+          command     => 'systemctl daemon-reload',
+          path        => [ '/usr/bin', '/bin', '/usr/sbin' ],
+        }
+      }
+      'init': {
+        file { '/etc/init.d/teleport':
+          ensure  => $ensure,
+          mode    => '0555',
+          owner   => 'root',
+          group   => 'root',
+          content => template('teleport/teleport.init.erb')
+        }
+      }
+      default: { fail('OS not supported') }
+    }~>
     service { 'teleport':
-      ensure   => $teleport::service_ensure,
+      ensure   => $ensure ? {
+        present => running,
+        absent => stopped,
+      },
       enable   => $teleport::service_enable,
-      provider => $teleport::init_style,
+      provider => $init_style,
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -42,6 +42,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">=3.2.0 <5.0.0"
+    },
+    {
+      "name": "puppet/archive",
+      "version_requirement": ">=1.1.0"
     }
   ]
 }


### PR DESCRIPTION
The teleport binary for Linux runs on CoreOS and systemd is available
for managing the service lifecycle. We extend the plugin to support
CoreOS by adding it to the list of supported operating system in
config.pp.

We expose other confguration parameters (archive_url, systemd_file) to
make the installation more flexible.

The archive module has been added as a direct dependency since it's
being used by the module.