### PR TITLE
Add checksum_type and checksum parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,12 @@
 #  Teleport nodename.
 #  Defaults to $::fqdn fact
 #
+# [*checksum_type*]
+#  The checksum type to use when determining whether to replace a file’s contents.
+#
+# [*checksum*]
+#  The checksum of the source contents.
+#
 # [*data_dir*]
 #  Teleport data directory
 #  Defaults to undef (meaning teleport uses its
@@ -146,6 +152,8 @@ class teleport (
   $bin_dir               = $teleport::params::bin_dir,
   $assets_dir            = $teleport::params::assets_dir,
   $nodename              = $teleport::params::nodename,
+  $checksum_type         = $teleport::params::checksum_type,
+  $checksum              = $teleport::params::checksum,
   $data_dir              = undef,
   $auth_token            = undef,
   $advertise_ip          = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,11 +29,13 @@ class teleport::install(
     ensure => $directory_ensure,
   } ->
   archive { $teleport::archive_path:
-    ensure       => $ensure,
-    extract      => true,
-    extract_path => $teleport::extract_path,
-    source       => $teleport::archive_url,
-    creates      => "${teleport::extract_path}/teleport"
+    ensure        => $ensure,
+    extract       => true,
+    extract_path  => $teleport::extract_path,
+    source        => $teleport::archive_url,
+    creates       => "${teleport::extract_path}/teleport"
+    checksum      => $teleport::checksum,
+    checksum_type => $teleport::checksum_type,
   } ->
   file {
     "${teleport::bin_dir}/tctl":


### PR DESCRIPTION
These parameters allow to specify a checksum to verify a given teleport
binary archive.

In this way we can keep the teleport archive name fixed
(teleport-latest.tar.gz) and only update its checksum when the package
needs to be updated.

Related puppet PR: https://github.com/monzo/puppet/pull/383/files